### PR TITLE
Fix bug background and font to generate print model

### DIFF
--- a/projects/angular-editor/src/lib/angular-editor.component.ts
+++ b/projects/angular-editor/src/lib/angular-editor.component.ts
@@ -216,6 +216,10 @@ export class AngularEditorComponent implements OnInit, ControlValueAccessor, Aft
     if ((!html || html === '<br>')) {
       html = '';
     }
+    if (this.config.clearBackgroundAndFont) {
+      html = html.replace(new RegExp("background-color: transparent;", "g"), "");
+      html = html.replace(new RegExp("font-family: Arial;", "g"), "");
+    }
     if (typeof this.onChange === 'function') {
       this.onChange(this.config.sanitize || this.config.sanitize === undefined ?
         this.sanitizer.sanitize(SecurityContext.HTML, html) : html);

--- a/projects/angular-editor/src/lib/config.ts
+++ b/projects/angular-editor/src/lib/config.ts
@@ -37,7 +37,8 @@ export interface AngularEditorConfig {
   toolbarPosition?: 'top' | 'bottom';
   outline?: boolean;
   toolbarHiddenButtons?: string[][];
-  rawPaste?: boolean;
+  rawPaste?: boolean;  
+  clearBackgroundAndFont?: boolean;
 }
 
 export const angularEditorConfig: AngularEditorConfig = {
@@ -66,6 +67,7 @@ export const angularEditorConfig: AngularEditorConfig = {
   sanitize: true,
   toolbarPosition: 'top',
   outline: true,
+  clearBackgroundAndFont: false,
   /*toolbarHiddenButtons: [
     ['bold', 'italic', 'underline', 'strikeThrough', 'superscript', 'subscript'],
     ['heading', 'fontName', 'fontSize', 'color'],


### PR DESCRIPTION
Fix a bug, that added "background-color: transparent;" and "font-family: Arial;", that didn´t let to generated a print model, made in PdfMake.